### PR TITLE
changed absolute paths to user-relative

### DIFF
--- a/main.py
+++ b/main.py
@@ -136,7 +136,7 @@ def remove_provider():
 @plugin.route('/review_channels')
 def review_channels():
     xbmcgui.Dialog().notification(xbmcaddon.Addon().getAddonInfo('name'), 'Updating channels config file...', get_icon_path('tv'), 3000)
-    subprocess.check_call("/storage/.kodi/addons/script.module.sd4tvh/bin/sd4tvh_channels")
+    subprocess.check_call(u".kodi/addons/script.module.sd4tvh/bin/sd4tvh_channels")
     user = plugin.get_setting('sd.username')
     pass1 = plugin.get_setting('sd.password')
     passw = hashlib.sha1(pass1.encode('utf-8')).hexdigest()
@@ -160,7 +160,7 @@ def review_channels():
     sel_line = xbmcgui.Dialog().select('Select Schedules Direct Lineup - Click to Edit Channels...', list=lineups)
     if sel_line >= 0:
         parser = ConfigParser.ConfigParser(allow_no_value=True)
-        parser.readfp(open(u"/storage/.kodi/userdata/addon_data/script.module.sd4tvh/filter.cfg"))
+        parser.readfp(open(u".kodi/userdata/addon_data/script.module.sd4tvh/filter.cfg"))
         lineup_longname = lineups[sel_line]
         lineup_name = lineupso[sel_line]
         lineup_new = lineup_name + "-new"
@@ -321,7 +321,7 @@ def review_channels():
                 parser.set(lineup_exc, channel_num_ret_exc, channel_nm_ret_exc)
                 parser.remove_option('temp-exc', channel_num_ret_exc)
             parser.remove_section('temp-exc')
-        with open(u"/storage/.kodi/userdata/addon_data/script.module.sd4tvh/filter.cfg", 'w') as fp:
+        with open(u".kodi/userdata/addon_data/script.module.sd4tvh/filter.cfg", 'w') as fp:
             fp.write("; sd4tvh channel filter\n")
             fp.write("; \n")
             fp.write("; Move channels to include under [<headend>-include].\n")

--- a/sd4tvh.py
+++ b/sd4tvh.py
@@ -403,5 +403,5 @@ def main():
         app.process()
 
 if __name__ == "__main__":
-    logging.config.fileConfig(u".kodi/addons/script.module.sd4tvh/logging.cfg", disable_existing_loggers=True)
+#    logging.config.fileConfig(u".kodi/addons/script.module.sd4tvh/logging.cfg", disable_existing_loggers=True)
     main()

--- a/sd4tvh.py
+++ b/sd4tvh.py
@@ -388,7 +388,7 @@ def main():
     optional_args.add_argument(u"--filter", dest=u"filter", action="store_true", default=False, help=u"Enable file-based channel filtering.")
     optional_args.add_argument(u"--filter-path", dest=u"filter_path", default=u"./filter.cfg", help=u"File path for channel filter configuration.")
     optional_args.add_argument(u"--channels", dest=u"channels", action="store_true", default=False, help=u"Create channel filter file.")
-    optional_args.add_argument(u"--channels-path", dest=u"channels_path", default=u"/storage/.kodi/userdata/addon_data/script.module.sd4tvh/filter.cfg", help=u"File path for channel filter configuration.")
+    optional_args.add_argument(u"--channels-path", dest=u"channels_path", default=u".kodi/userdata/addon_data/script.module.sd4tvh/filter.cfg", help=u"File path for channel filter configuration.")
 
     args = parser.parse_args()
 
@@ -403,5 +403,5 @@ def main():
         app.process()
 
 if __name__ == "__main__":
-    logging.config.fileConfig(u"/storage/.kodi/addons/script.module.sd4tvh/logging.cfg", disable_existing_loggers=True)
+    logging.config.fileConfig(u".kodi/addons/script.module.sd4tvh/logging.cfg", disable_existing_loggers=True)
     main()


### PR DESCRIPTION
Tried to get openelec working, but the new build doesn't seem to have the tvheadend server. Here is a quick fix to get this working on OSMC instead. I changed the absolute paths pointing to /storage/.kodi to just ~/.kodi. That should work as well on openelec since it's based on a root user, while osmc is based on a default osmc user.

I also had to copy the tv_grab_sd4tvh script into /usr/bin manually since just installing from the zip file didn't do that for me. I'm not sure what to change here to allow that to happen automatically.