### PR TITLE
Re-enable logging for LibreELEC

### DIFF
--- a/sd4tvh.py
+++ b/sd4tvh.py
@@ -108,6 +108,7 @@ class sd4tvh:
             channel_filter.add_channel_filter(cf)
 
         station_ids = [station.station_id for station in lineup_map_list.unique_stations(channel_filter)]
+        self._logger.info(u"Station ids found: %s", len(station_ids))
 
         self._logger.info(u"Getting schedule hashes...")
         schedule_hash_list = self._sd.get_schedule_hash_list(station_ids)

--- a/sd4tvh.py
+++ b/sd4tvh.py
@@ -4,6 +4,7 @@
 import argparse
 import logging
 import logging.config
+import os
 from xmltv import XmltvChannel, XmltvProgramme, XmltvWriter
 from libschedulesdirect.common import Status, Program, Broadcast, Channel, ProgramArtwork, StationLogo
 from libschedulesdirect.schedulesdirect import SchedulesDirect
@@ -403,5 +404,7 @@ def main():
         app.process()
 
 if __name__ == "__main__":
-#    logging.config.fileConfig(u".kodi/addons/script.module.sd4tvh/logging.cfg", disable_existing_loggers=True)
+    logging_cfg = u"/storage/.kodi/addons/script.module.sd4tvh/logging.cfg"
+    if os.path.isfile(logging_cfg):
+        logging.config.fileConfig(logging_cfg, disable_existing_loggers=True)
     main()


### PR DESCRIPTION
Logging was disabled for all operating systems with the following commit:
    
   also had to disable logging for osmc  
   6dea35df88d2586c26c23f8c628967d3f0af146f
    
Previous to the above mentioned commit the path for the logging configuration file was set to work with OpenELEC (now forked to LibreELEC).
    
Enable logging to once again work with LibreELEC, but remain disabled for osmc.

Also add logging of number of station ids found.  This is useful when troubleshooting with multiple station sources and lineups, such as Over-The-Air via HDHomerun tuners and Over-The-Internet via IPTV.